### PR TITLE
Flesh out API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "flatbush",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 flatbush = { git = "https://github.com/kylebarron/flatbush-rs", rev = "5e5cdbf3f5ed033fa9db4e7be4f78fa83945511c" }
+thiserror = "1"
 
 
 [dev-dependencies]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use flatbush::kdbush::r#trait::KdbushIndex;
+use flatbush::kdbush::KdbushIndex;
 
 use crate::cluster::{ClusterData, ClusterId};
 use crate::options::SuperclusterOptions;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,9 @@
+use std::fmt::Debug;
+use thiserror::Error;
+
+/// Enum with all errors in this crate.
+#[derive(Error, Debug)]
+pub enum SuperclusterError {
+    #[error("No cluster with the specified id.")]
+    NoClusterFound,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod builder;
 pub mod cluster;
+pub mod error;
 pub mod options;
 pub mod supercluster;
 pub mod tree;


### PR DESCRIPTION
Fleshes out the API for every relevant supercluster method except for `get_tile`. 